### PR TITLE
Update MAST alt registry RegTAP service link to mast.stsci.edu

### DIFF
--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -597,7 +597,7 @@ You can pre-select the URL by setting the ``IVOA_REGISTRY`` environment
 variable to the TAP access URL of the service you would like to use.  In
 a bash-like shell, you would say::
 
-  export IVOA_REGISTRY="http://vao.stsci.edu/RegTAP/TapService.aspx"
+  export IVOA_REGISTRY="https://mast.stsci.edu/vo-tap/api/v0.1/registry"
 
 before starting python (or the notebook processor).
 
@@ -620,7 +620,7 @@ RegTAP services using:
   http://gavo.aip.de/tap
   http://voparis-rr.obspm.fr/tap
   https://registry.euro-vo.org/regtap/tap
-  https://vao.stsci.edu/RegTAP/TapService.aspx
+  https://mast.stsci.edu/vo-tap/api/v0.1/registry
 
 
 

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -619,8 +619,8 @@ RegTAP services using:
   http://dc.g-vo.org/tap
   http://gavo.aip.de/tap
   http://voparis-rr.obspm.fr/tap
-  https://registry.euro-vo.org/regtap/tap
   https://mast.stsci.edu/vo-tap/api/v0.1/registry
+  https://registry.euro-vo.org/regtap/tap
 
 
 

--- a/docs/registry/index.rst
+++ b/docs/registry/index.rst
@@ -619,6 +619,7 @@ RegTAP services using:
   http://dc.g-vo.org/tap
   http://gavo.aip.de/tap
   http://voparis-rr.obspm.fr/tap
+  https://registry.euro-vo.org/regtap/tap
   https://vao.stsci.edu/RegTAP/TapService.aspx
 
 

--- a/pyvo/registry/tests/test_regtap.py
+++ b/pyvo/registry/tests/test_regtap.py
@@ -930,7 +930,7 @@ def test_sia2_service_operation():
 
 @pytest.mark.remote_data
 def test_endpoint_switching():
-    alt_svc = "http://vao.stsci.edu/RegTAP/TapService.aspx"
+    alt_svc = "https://mast.stsci.edu/vo-tap/api/v0.1/registry"
     previous_url = regtap.REGISTRY_BASEURL
     try:
         regtap.choose_RegTAP_service(alt_svc)


### PR DESCRIPTION
Updates the links to MAST's registry under 'alt registry' options, to MAST's newer Python service under active maintenance. The vao.stsci.edu version is slated for decommissioning once critical traffic has been moved.